### PR TITLE
feat: Revamp Pomodoro mode UI and related elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-Live Preview : https://timer-x-kappa.vercel.app/
+# TimerX
+
+A simple and easy-to-use timer application built with Next.js, React, and Tailwind CSS.
+
+Live Preview: https://timer-x-kappa.vercel.app/
+
+## Features (Updated)
+
+- Set custom timer durations (minutes and seconds).
+- Start, pause, and reset the timer.
+- Audible alarm when the timer finishes.
+- Browser notification when the timer finishes.
+- Real-time clock display.
+- **Pomodoro Timer Mode:**
+    - Configurable work, short break, and long break durations.
+    - Configurable number of work cycles before a long break.
+    - Automatic cycling through work and break periods.
+    - Display of current Pomodoro phase (Work, Short Break, Long Break).
+    - Count of completed Pomodoros.
+
+## Using the Pomodoro Timer
+
+1.  **Switch to Pomodoro Mode:** Click the "Switch to Pomodoro Timer" button.
+2.  **Configure Durations (Optional):** Adjust the default durations for work sessions, short breaks, and long breaks, as well as the number of work cycles before a long break, using the settings panel that appears in Pomodoro mode.
+3.  **Start the Timer:** Click the "Start" button to begin your first work session.
+4.  The timer will automatically cycle through work and break periods, playing an alarm and sending a notification at the end of each period.
+5.  You can pause, reset, or switch back to the regular timer mode at any time. Resetting in Pomodoro mode will bring you back to the start of a work cycle with your current settings.
+
+## Getting Started
+
+To run this project locally:
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository-url>
+    cd timer-x
+    ```
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+3.  **Run the development server:**
+    ```bash
+    npm run dev
+    ```
+    Open [http://localhost:3000](http://localhost:3000) in your browser to see the application.
+
+## Technologies Used
+
+- [Next.js](https://nextjs.org/) - React framework for server-side rendering and static site generation.
+- [React](https://reactjs.org/) - JavaScript library for building user interfaces.
+- [TypeScript](https://www.typescriptlang.org/) - Typed superset of JavaScript.
+- [Tailwind CSS](https://tailwindcss.com/) - Utility-first CSS framework.
+
+## Contributing
+
+Contributions are welcome! If you have any ideas, suggestions, or find any bugs, please open an issue or submit a pull request.
+
+Made with 🍕

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,8 +15,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={inter.className}>{children}</body>
+    <html lang="en" className="h-full">
+      <body className={`${inter.className} h-full`}>{children}</body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,18 @@
 'use client';
-import Timer from './timer';
+import Timer, { PomodoroSettingsType } from './timer';
 import React, { useState, useEffect } from 'react';
 
 export default function Home() {
   const [currentTime, setCurrentTime] = useState<string>('');
+  const [pomodoroMode, setPomodoroMode] = useState<boolean>(false);
+  const initialPomodoroSettings: PomodoroSettingsType = {
+    workDuration: 25 * 60,
+    shortBreakDuration: 5 * 60,
+    longBreakDuration: 15 * 60,
+    cyclesBeforeLongBreak: 4,
+  };
+  const [pomodoroSettings, setPomodoroSettings] = useState<PomodoroSettingsType>(initialPomodoroSettings);
+
 
   useEffect(() => {
     setCurrentTime(new Date().toLocaleTimeString());
@@ -14,9 +23,9 @@ export default function Home() {
     return () => clearInterval(intervalId);
   }, []);
   return (
-    <main >
+    <main className="flex flex-col min-h-screen">
       <div className="p-5 w-full items-center justify-between font-mono text-sm lg:flex shadow-lg shadow-cyan-500/50">
-        <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300S bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
+        <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
           
           <code className="font-mono font-bold">{currentTime}</code>
         </p>
@@ -25,10 +34,94 @@ export default function Home() {
         </div>
       </div>
 
-      <div className="p-10 justify-center font-bold">
-      <Timer />
+      <div className="flex flex-col items-center flex-grow w-full px-4 py-8 visible opacity-100">
+        {/* Conditional Layout: Side-by-side for Pomodoro, Centered Timer for Regular */}
+        {pomodoroMode ? (
+          <div className="flex flex-col md:flex-row md:items-start w-full flex-grow mt-4 gap-4">
+            {/* Left: Settings Panel */}
+            <div className="p-4 md:p-6 bg-gray-200 dark:bg-zinc-800/30 rounded-lg shadow-lg w-full md:w-1/3 lg:w-1/4">
+              <h2 className="text-xl font-semibold mb-4 text-center text-gray-800 dark:text-gray-200">Pomodoro Settings</h2>
+              <div className="grid grid-cols-1 gap-4">
+                <div>
+                  <label htmlFor="workDuration" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Work (min)</label>
+                  <input
+                    type="number"
+                    id="workDuration"
+                    min="1"
+                    value={pomodoroSettings.workDuration / 60}
+                    onChange={(e) => setPomodoroSettings(s => ({ ...s, workDuration: Math.max(1, parseInt(e.target.value) || 1) * 60 }))}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="shortBreakDuration" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Short Break (min)</label>
+                  <input
+                    type="number"
+                    id="shortBreakDuration"
+                    min="1"
+                    value={pomodoroSettings.shortBreakDuration / 60}
+                    onChange={(e) => setPomodoroSettings(s => ({ ...s, shortBreakDuration: Math.max(1, parseInt(e.target.value) || 1) * 60 }))}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="longBreakDuration" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Long Break (min)</label>
+                  <input
+                    type="number"
+                    id="longBreakDuration"
+                    min="1"
+                    value={pomodoroSettings.longBreakDuration / 60}
+                    onChange={(e) => setPomodoroSettings(s => ({ ...s, longBreakDuration: Math.max(1, parseInt(e.target.value) || 1) * 60 }))}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="cyclesBeforeLongBreak" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Cycles for Long Break</label>
+                  <input
+                    type="number"
+                    id="cyclesBeforeLongBreak"
+                    min="1"
+                    value={pomodoroSettings.cyclesBeforeLongBreak}
+                    onChange={(e) => setPomodoroSettings(s => ({ ...s, cyclesBeforeLongBreak: Math.max(1, parseInt(e.target.value) || 1) }))}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  />
+                </div>
+              </div>
+            </div>
+            {/* Right: Timer */}
+            <div className="p-4 md:p-10 flex-grow flex justify-center items-center w-full md:w-auto">
+              <Timer
+                key={pomodoroMode ? 'pomodoro' : 'regular'}
+                pomodoroMode={pomodoroMode}
+                pomodoroSettings={pomodoroSettings}
+              />
+            </div>
+          </div>
+        ) : (
+          // Regular mode: Timer centered
+          <div className="p-10 justify-center font-bold flex-grow flex items-center w-full">
+            <Timer
+              key={pomodoroMode ? 'pomodoro' : 'regular'}
+              pomodoroMode={pomodoroMode}
+              pomodoroSettings={pomodoroSettings}
+            />
+          </div>
+        )}
       </div>
-    <footer className="font-bold text-lg text-slate-400 text-center py-5">Made with 🍕</footer>
+
+      {/* Moved Pomodoro Toggle Button Wrapper - new position */}
+      <div className="flex flex-col items-center py-4 w-full">
+        <button
+          onClick={() => {
+            setPomodoroMode(!pomodoroMode);
+          }}
+          className="px-6 py-3 bg-blue-700 hover:bg-blue-800 text-white rounded-lg shadow-md transition-transform hover:scale-105 duration-150 text-lg"
+        >
+          {pomodoroMode ? 'Switch to Regular Timer' : 'Switch to Pomodoro Timer'}
+        </button>
+      </div>
+
+    <footer className="font-bold text-lg text-slate-400 text-center py-5 mt-auto">Made with 🍕</footer>
     </main>
   );
 }

--- a/src/app/timer.tsx
+++ b/src/app/timer.tsx
@@ -1,16 +1,63 @@
+export interface PomodoroSettingsType {
+  workDuration: number; // in seconds
+  shortBreakDuration: number; // in seconds
+  longBreakDuration: number; // in seconds
+  cyclesBeforeLongBreak: number;
+}
+
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
 
-const Timer: React.FC = () => {
+interface TimerProps {
+  pomodoroMode: boolean;
+  pomodoroSettings: PomodoroSettingsType;
+}
+
+const Timer: React.FC<TimerProps> = ({ pomodoroMode, pomodoroSettings }) => {
   const [inputMinutes, setInputMinutes] = useState<string>('0');
   const [inputSeconds, setInputSeconds] = useState<string>('0');
   const [time, setTime] = useState<number>(0);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
+  // Pomodoro specific states (internal to Timer component)
+  const [pomodoroCycle, setPomodoroCycle] = useState<'work' | 'shortBreak' | 'longBreak'>('work');
+  const [pomodorosCompleted, setPomodorosCompleted] = useState<number>(0);
+
+  // Effect to correctly initialize/reset Pomodoro state when mode changes or on initial load in Pomodoro mode
   useEffect(() => {
-    // Request notification permission
+    if (pomodoroMode) {
+      setTime(pomodoroSettings.workDuration);
+      setPomodoroCycle('work');
+      setPomodorosCompleted(0);
+      setIsRunning(false); // Start paused
+    } else {
+      // If switching from Pomodoro to regular, reset time and stop.
+      // If already in regular, this key change from page.tsx should handle reset if needed.
+      setTime(0);
+      setInputMinutes('0');
+      setInputSeconds('0');
+      setIsRunning(false);
+    }
+  }, [pomodoroMode, pomodoroSettings.workDuration]); // pomodoroSettings.workDuration is a stable part of the object prop
+
+  // Effect to update displayed time if settings for the current PAUSED cycle are changed by the user
+  useEffect(() => {
+    if (pomodoroMode && !isRunning) {
+      if (pomodoroCycle === 'work') {
+        setTime(pomodoroSettings.workDuration);
+      } else if (pomodoroCycle === 'shortBreak') {
+        setTime(pomodoroSettings.shortBreakDuration);
+      } else if (pomodoroCycle === 'longBreak') {
+        setTime(pomodoroSettings.longBreakDuration);
+      }
+    }
+  }, [pomodoroMode, isRunning, pomodoroCycle, pomodoroSettings]);
+
+
+  // Main timer countdown and Pomodoro cycle logic
+  useEffect(() => {
     if ("Notification" in window && Notification.permission !== "granted") {
       Notification.requestPermission();
     }
@@ -21,43 +68,85 @@ const Timer: React.FC = () => {
         setTime((prevTime) => prevTime - 1);
       }, 1000);
     } else if (time === 0 && isRunning) {
-      setIsRunning(false);
       handleTimerEnd();
+      if (pomodoroMode) {
+        let nextCycleInternal: 'work' | 'shortBreak' | 'longBreak' = pomodoroCycle;
+        let nextTimeInternal: number;
+        let currentPomodorosCompleted = pomodorosCompleted;
+
+        if (pomodoroCycle === 'work') {
+          currentPomodorosCompleted++;
+          setPomodorosCompleted(currentPomodorosCompleted);
+          if (currentPomodorosCompleted > 0 && currentPomodorosCompleted % pomodoroSettings.cyclesBeforeLongBreak === 0) {
+            nextCycleInternal = 'longBreak';
+            nextTimeInternal = pomodoroSettings.longBreakDuration;
+          } else {
+            nextCycleInternal = 'shortBreak';
+            nextTimeInternal = pomodoroSettings.shortBreakDuration;
+          }
+        } else { // shortBreak or longBreak
+          nextCycleInternal = 'work';
+          nextTimeInternal = pomodoroSettings.workDuration;
+        }
+        setPomodoroCycle(nextCycleInternal);
+        setTime(nextTimeInternal);
+        setIsRunning(true); // Auto-start next cycle
+      } else {
+        setIsRunning(false);
+      }
     }
     return () => clearInterval(timer);
-  }, [isRunning, time]);
+  }, [isRunning, time, pomodoroMode, pomodoroSettings, pomodoroCycle, pomodorosCompleted]);
 
-  const handleStart = () => setIsRunning(true);
+  const handleStart = () => {
+    // In Pomodoro mode, time is set by effects or cycle transitions.
+    // In regular mode, if time is 0, it shouldn't start. This is handled by button disabled state.
+    // If time is 0 and pomodoroMode is true, the effect for pomodoroMode change already set the initial work duration.
+    if (pomodoroMode && time === 0 && pomodoroCycle === 'work' && pomodorosCompleted === 0) {
+       setTime(pomodoroSettings.workDuration);
+    }
+    setIsRunning(true);
+  };
+
   const handlePause = () => setIsRunning(false);
+
   const handleReset = () => {
     setIsRunning(false);
-    setTime(0);
-    setInputMinutes('0');
-    setInputSeconds('0');
     stopSound();
+    if (pomodoroMode) {
+      setTime(pomodoroSettings.workDuration);
+      setPomodoroCycle('work');
+      setPomodorosCompleted(0);
+    } else {
+      setTime(0);
+      setInputMinutes('0');
+      setInputSeconds('0');
+    }
   };
 
   const handleSetTime = () => {
+    if (pomodoroMode) return; // Should be disabled, but as a safeguard
     const minutes = parseInt(inputMinutes, 10);
     const seconds = parseInt(inputSeconds, 10);
     if ((!isNaN(minutes) && minutes >= 0) && (!isNaN(seconds) && seconds >= 0)) {
-      setTime(minutes * 60 + seconds);
+      const newTime = minutes * 60 + seconds;
+      setTime(newTime);
+      if (newTime === 0) {
+        setIsRunning(false);
+      }
     }
   };
 
-  const formatTime = (time: number) => {
-    const minutes = Math.floor(time / 60);
-    const seconds = time % 60;
+  const formatTime = (timeInSeconds: number) => {
+    const minutes = Math.floor(timeInSeconds / 60);
+    const seconds = timeInSeconds % 60;
     return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
   };
 
   const handleTimerEnd = () => {
-    // Send notification
     if ("Notification" in window && Notification.permission === "granted") {
       new Notification("Time's up!");
     }
-
-    // Play sound
     if (audioRef.current) {
       audioRef.current.play();
     }
@@ -72,49 +161,63 @@ const Timer: React.FC = () => {
 
   return (
     <div className="text-center p-4 flex flex-col items-center space-y-4">
-      <h1 className="text-6xl font-bold my-4 transition-transform transform hover:scale-110">
+      <h1 className="text-9xl font-bold my-4 transition-transform transform hover:scale-110">
         {formatTime(time)}
       </h1>
+
+      {pomodoroMode && (
+        <div className="my-3 text-center">
+          <p className="text-xl font-semibold text-gray-700 dark:text-gray-200">Mode: Pomodoro</p>
+          <p className="text-lg capitalize text-gray-600 dark:text-gray-300">Current Phase: {pomodoroCycle.replace('Break', ' Break')}</p>
+          <p className="text-lg text-gray-600 dark:text-gray-300">Pomodoros Completed: {pomodorosCompleted}</p>
+        </div>
+      )}
+
       <div className="flex flex-col items-center space-y-4">
-        <label>min🔻</label>
+        <label htmlFor="inputMinutes" className="text-sm font-medium text-gray-700 dark:text-gray-300">Minutes</label>
         <input
+          id="inputMinutes"
           type="number"
           value={inputMinutes}
           onChange={(e) => setInputMinutes(e.target.value)}
           placeholder="Minutes"
-          className="w-22 px-4 py-2 border rounded text-lg text-zinc-800"
+          disabled={pomodoroMode}
+          className="w-32 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded text-lg text-zinc-800 dark:text-zinc-200 bg-white dark:bg-gray-700 disabled:opacity-60 disabled:cursor-not-allowed"
         />
-        <label>sec🔻</label>
+        <label htmlFor="inputSeconds" className="text-sm font-medium text-gray-700 dark:text-gray-300">Seconds</label>
         <input
+          id="inputSeconds"
           type="number"
           value={inputSeconds}
           onChange={(e) => setInputSeconds(e.target.value)}
           placeholder="Seconds"
-          className="w-22 px-4 py-2 border rounded text-lg text-zinc-800"
+          disabled={pomodoroMode}
+          className="w-32 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded text-lg text-zinc-800 dark:text-zinc-200 bg-white dark:bg-gray-700 disabled:opacity-60 disabled:cursor-not-allowed"
         />
-        <button 
-          onClick={handleSetTime} 
-          className="px-6 py-2 bg-blue-700 text-white rounded "
+        <button
+          onClick={handleSetTime}
+          className="px-6 py-3 bg-blue-700 text-white rounded hover:bg-blue-800 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+          disabled={pomodoroMode}
         >
-          Set Timer
+          Set Custom Timer
         </button>
       </div>
       <div className=" flex space-x-3 items-center ">
-        <button 
-          onClick={handleStart} 
-          disabled={isRunning || time === 0}
-          className="px-4 py-2 bg-green-700 text-white rounded  disabled:opacity-50"
+        <button
+          onClick={handleStart}
+          disabled={isRunning || (time === 0 && !pomodoroMode) || (pomodoroMode && isRunning)}
+          className="px-4 py-2 bg-green-700 text-white rounded disabled:opacity-50"
         >
           Start
         </button>
-        <button 
-          onClick={handlePause} 
+        <button
+          onClick={handlePause}
           disabled={!isRunning}
           className="px-4 py-2 bg-yellow-700 text-white rounded disabled:opacity-50"
         >
           Pause
         </button>
-        <button 
+        <button
           onClick={handleReset}
           className="px-4 py-2 bg-red-700 text-white rounded "
         >


### PR DESCRIPTION
This commit implements several UI enhancements based on your feedback to improve the layout, usability, and theme consistency of the Pomodoro timer feature and related page elements.

Key changes:

1.  **Side-by-Side Pomodoro Layout (`page.tsx`):**
    - When Pomodoro mode is active, the settings panel and the timer display are now arranged side-by-side on medium screens and wider. The settings panel appears on the left (e.g., md:w-1/3), and the timer on the right (e.g., flex-grow).
    - On smaller screens, this layout stacks vertically for better usability.
    - The Pomodoro settings panel background has been updated to `bg-gray-200 dark:bg-zinc-800/30` to align with the header card style.

2.  **"Switch to Pomodoro Timer" Button (`page.tsx`):**
    - Relocated from the top of the content area to a position just above the footer, centered horizontally.
    - Button color changed from purple to blue (`bg-blue-700 hover:bg-blue-800`) for better theme consistency with other action buttons.
    - Added a hover animation (`hover:scale-105 transition-transform`).

3.  **Timer Display Size (`timer.tsx`):**
    - Increased the font size of the main timer digits (e.g., "00:00") from `text-6xl` to `text-9xl` for significantly improved visibility.

These changes aim to provide a more refined and user-friendly experience when interacting with the Pomodoro timer functionality.